### PR TITLE
Enable Link-Time Optimization (LTO)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,3 +47,6 @@ rexpect = "0.5.0"
 
 [profile.dev]
 debug = 0
+
+[profile.release]
+lto = true


### PR DESCRIPTION
Hi!

I noticed that in the `Cargo.toml` file Link-Time Optimization (LTO) for the project is not enabled. I suggest switching it on since it will reduce the binary size (always a good thing to have).

I have made quick tests (Fedora 41, Rustc 1.83) by adding `lto = true` to the Release profile. The binary size reduction is from 3 Mib to 2.4 Mib.

Thank you.